### PR TITLE
Add Order minion

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/bin/catalog-api-order-minion
+++ b/bin/catalog-api-order-minion
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+lib = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+STDOUT.sync = true
+
+require "bundler/setup"
+require "catalog/minion"
+
+def parse_args
+  require 'optimist'
+  opts = Optimist.options do
+    opt :queue_host, "Hostname of the Platform's kafka queue", :type => :string,
+        :default => ENV["QUEUE_HOST"] || "localhost"
+    opt :queue_port, "Port of the Platform's kafka queue", :type => :int,
+        :default => (ENV["QUEUE_PORT"] || 9092).to_i, :required => false
+  end
+
+  opts
+end
+
+args = parse_args
+
+catalog_api_minion_order = Catalog::Api::Minion::Order.new(args[:queue_host], args[:queue_port])
+catalog_api_minion_order.run

--- a/bin/catalog-api-order-minion
+++ b/bin/catalog-api-order-minion
@@ -20,6 +20,13 @@ def parse_args
   opts
 end
 
+require "catalog-api-client"
+CatalogApiClient.configure do |config|
+  config.scheme = ENV["CATALOG_SCHEME"] || "http"
+  config.host   = "#{ENV["CATALOG_HOST"]}:#{ENV["CATALOG_PORT"]}"
+  config.logger = Catalog::Api::Minion.logger
+end
+
 args = parse_args
 
 catalog_api_minion_order = Catalog::Api::Minion::Order.new(args[:queue_host], args[:queue_port])

--- a/lib/catalog/api/minion/order.rb
+++ b/lib/catalog/api/minion/order.rb
@@ -1,0 +1,51 @@
+require 'catalog-api-client'
+require "rest-client"
+require "catalog/api/minion/base"
+require "uri"
+
+module Catalog
+  module Api
+    class Minion
+      class Order < Base
+        include Logging
+
+        def base_name
+          "Catalog API Order Minion"
+        end
+
+        def queue_name
+          "platform.topological-inventory.task-output-stream".freeze
+        end
+
+        def persist_ref
+          "catalog-api-order-minion".freeze
+        end
+
+        def perform(message)
+          jobtype = message.message
+          payload = message.payload
+          payload_params = {:payload =>  message.payload, :message => jobtype}
+
+          logger.info("#{jobtype}: #{payload}")
+          response = post_internal_notify(payload, payload_params)
+          logger.info("#{response}")
+        end
+
+        private
+
+        def post_internal_notify(payload, payload_params)
+          RestClient.post(internal_notify_url(payload['task_id']), payload_params, identity_headers(persist_ref))
+        end
+
+        def internal_notify_url(task_id)
+          config = ::CatalogApiClient.configure
+          URI::HTTP.build(
+            :host   => config.host.split(":").first,
+            :port   => config.host.split(":").last,
+            :path   => "/internal/v1.0/notify/order_item/#{task_id}"
+          ).to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/catalog/api/minion/order.rb
+++ b/lib/catalog/api/minion/order.rb
@@ -38,13 +38,11 @@ module Catalog
         end
 
         def internal_notify_url(task_id)
-          # config = ::CatalogApiClient.configure
+          config = ::CatalogApiClient.configure
           URI::HTTP.build(
-            :host   => "catalog-api.catalog-ci.svc",
-            :port   => "8080",
+            :host   => config.host.split(":").first,
+            :port   => config.host.split(":").last,
             :path   => "/internal/v1.0/notify/order_item/#{task_id}"
-            # :host   => config.host.split(":").first,
-            # :port   => config.host.split(":").last,
           ).to_s
         end
       end

--- a/lib/catalog/api/minion/order.rb
+++ b/lib/catalog/api/minion/order.rb
@@ -38,11 +38,13 @@ module Catalog
         end
 
         def internal_notify_url(task_id)
-          config = ::CatalogApiClient.configure
+          # config = ::CatalogApiClient.configure
           URI::HTTP.build(
-            :host   => config.host.split(":").first,
-            :port   => config.host.split(":").last,
+            :host   => "catalog-api.catalog-ci.svc",
+            :port   => "8080",
             :path   => "/internal/v1.0/notify/order_item/#{task_id}"
+            # :host   => config.host.split(":").first,
+            # :port   => config.host.split(":").last,
           ).to_s
         end
       end

--- a/lib/catalog/minion.rb
+++ b/lib/catalog/minion.rb
@@ -1,4 +1,5 @@
 require "catalog/api/minion/approval"
+require "catalog/api/minion/order"
 require "catalog/api/minion/logging"
 require "catalog/api/minion/version"
 require "catalog/api/minion/base"

--- a/spec/catalog/api/minion/order_spec.rb
+++ b/spec/catalog/api/minion/order_spec.rb
@@ -1,0 +1,34 @@
+require "catalog/minion"
+
+describe Catalog::Api::Minion::Order do
+  describe "#perform" do
+    let(:order) do
+      described_class.new("localhost", "9092")
+    end
+    let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, "request_started", payload, nil, nil, nil) }
+    let(:payload) { {"task_id" => "123"} }
+    let(:payload_params) do
+      {:payload =>  message.payload, :message => message.message}
+    end
+    let(:config) do
+      test_config = ::CatalogApiClient.configure
+      test_config.host = "localhost:3000"
+    end
+
+    before do
+      dummy_client = double("CatalogApiClient")
+      allow(dummy_client).to receive(:configure).and_return(config)
+      stub_request(:post, "http://localhost:3000/internal/v1.0/notify/order_item/123")
+    end
+
+    it "posts a payload" do
+      order.perform(message)
+      expect(a_request(:post, "http://localhost:3000/internal/v1.0/notify/order_item/123").with(
+        :body    => {"message"=>"request_started", "payload"=>{"task_id"=>"123"}},
+        :headers => {
+          'X-Rh-Identity'=>'eyJlbnRpdGxlbWVudHMiOnsiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfX0sImlkZW50aXR5Ijp7ImFjY291bnRfbnVtYmVyIjoiY2F0YWxvZy1hcGktb3JkZXItbWluaW9uIn19'
+        }
+      )).to have_been_made.once
+    end
+  end
+end

--- a/spec/catalog/api/minion/order_spec.rb
+++ b/spec/catalog/api/minion/order_spec.rb
@@ -10,15 +10,14 @@ describe Catalog::Api::Minion::Order do
     let(:payload_params) do
       {:payload =>  message.payload, :message => message.message}
     end
-    # TODO: Use config once we have e2e-deploy
-    # let(:config) do
-    #   test_config = ::CatalogApiClient.configure
-    #   test_config.host = "catalog-api.catalog-ci.svc"
-    # end
+    let(:config) do
+      test_config = ::CatalogApiClient.configure
+      test_config.host = "catalog-api.catalog-ci.svc:8080"
+    end
 
     before do
-      # dummy_client = double("CatalogApiClient")
-      # allow(dummy_client).to receive(:configure).and_return(config)
+      dummy_client = double("CatalogApiClient")
+      allow(dummy_client).to receive(:configure).and_return(config)
       stub_request(:post, "http://catalog-api.catalog-ci.svc:8080/internal/v1.0/notify/order_item/123")
     end
 

--- a/spec/catalog/api/minion/order_spec.rb
+++ b/spec/catalog/api/minion/order_spec.rb
@@ -10,20 +10,21 @@ describe Catalog::Api::Minion::Order do
     let(:payload_params) do
       {:payload =>  message.payload, :message => message.message}
     end
-    let(:config) do
-      test_config = ::CatalogApiClient.configure
-      test_config.host = "localhost:3000"
-    end
+    # TODO: Use config once we have e2e-deploy
+    # let(:config) do
+    #   test_config = ::CatalogApiClient.configure
+    #   test_config.host = "catalog-api.catalog-ci.svc"
+    # end
 
     before do
-      dummy_client = double("CatalogApiClient")
-      allow(dummy_client).to receive(:configure).and_return(config)
-      stub_request(:post, "http://localhost:3000/internal/v1.0/notify/order_item/123")
+      # dummy_client = double("CatalogApiClient")
+      # allow(dummy_client).to receive(:configure).and_return(config)
+      stub_request(:post, "http://catalog-api.catalog-ci.svc:8080/internal/v1.0/notify/order_item/123")
     end
 
     it "posts a payload" do
       order.perform(message)
-      expect(a_request(:post, "http://localhost:3000/internal/v1.0/notify/order_item/123").with(
+      expect(a_request(:post, "http://catalog-api.catalog-ci.svc:8080/internal/v1.0/notify/order_item/123").with(
         :body    => {"message"=>"request_started", "payload"=>{"task_id"=>"123"}},
         :headers => {
           'X-Rh-Identity'=>'eyJlbnRpdGxlbWVudHMiOnsiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfX0sImlkZW50aXR5Ijp7ImFjY291bnRfbnVtYmVyIjoiY2F0YWxvZy1hcGktb3JkZXItbWluaW9uIn19'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,11 +6,12 @@ end
 ENV["RAILS_ENV"] ||= "test"
 raise "Specs must be run in test environment" if ENV["RAILS_ENV"] != "test"
 
+require "webmock/rspec"
 require "catalog/api/minion/logging"
 Catalog::Api::Minion.logger = Logger.new("/dev/null")
 
 RSpec.configure do |config|
-  config.use_transactional_fixtures = true
+  # config.use_transactional_fixtures = true
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
This PR adds what used to be the "update order listener" service from catalog-api into a minion. A subsequent PR needs to be created in the catalog-api repo to remove that service so that this one becomes the standard instead.

When writing the specs for the minion I realized we weren't even using the `spec_helper.rb` file, so I included that in the `.rspec` file, which promptly broke things because `.use_transactional_fixtures` is an active record thing and we're not using active record in this project.

It also utilizes the new endpoint created for order in https://github.com/ManageIQ/catalog-api/pull/326, so could technically be merged into this repo but not used without breaking until that PR has been merged.

@miq-bot add_reviewer @lindgrenj6, @syncrou 