### PR TITLE
Correct the pull request URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/topological_inventory-sync. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/RedHatInsights/catalog-api-minion/pulls. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 


### PR DESCRIPTION
Since the README was just kinda copied from topology, the URL for pull requests was wrong, and it would've needed to change when we transferred to RedHatInsights anyway.