### PR TITLE
Allow for persist_ref to be set by env variable

### DIFF
--- a/lib/catalog/api/minion/approval.rb
+++ b/lib/catalog/api/minion/approval.rb
@@ -17,7 +17,7 @@ module Catalog
         end
 
         def persist_ref
-          "catalog-api-approval-minion".freeze
+          ENV["APPROVAL_PERSIST_REF"] || "catalog-api-approval-minion".freeze
         end
 
         private

--- a/lib/catalog/api/minion/task.rb
+++ b/lib/catalog/api/minion/task.rb
@@ -16,7 +16,7 @@ module Catalog
         end
 
         def persist_ref
-          "catalog-api-task-minion".freeze
+          ENV["TASK_PERSIST_REF"] || "catalog-api-task-minion".freeze
         end
 
         private


### PR DESCRIPTION
Allows for custom `persist_ref` to be set per minion deployment.

This allows each minion to register with the same topic but grab the kafka events independant of one another.