### PR TITLE
Removed references to catalog-api-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem "catalog-api-client", :git => "https://github.com/mkanoor/catalog-api-client-ruby.git", :branch => "master"
 gem "cloudwatchlogger", "~> 0.2"
 gem "concurrent-ruby"
 gem "more_core_extensions"
@@ -16,6 +15,7 @@ gem "manageiq-loggers", "~> 0.3.0"
 gem "manageiq-messaging", "~> 0.1.2"
 
 group :development, :test do
+  gem 'climate_control'
   gem "rspec"
   gem "simplecov"
   gem "webmock"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "concurrent-ruby"
 gem "more_core_extensions"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
-gem "rake"
+gem "rake", "~> 13.0.0"
 gem "rest-client", ">= 1.8.0"
 
 gem "manageiq-loggers", "~> 0.3.0"

--- a/bin/catalog-api-approval-minion
+++ b/bin/catalog-api-approval-minion
@@ -20,13 +20,6 @@ def parse_args
   opts
 end
 
-require "catalog-api-client"
-CatalogApiClient.configure do |config|
-  config.scheme = ENV["CATALOG_SCHEME"] || "http"
-  config.host   = "#{ENV["CATALOG_HOST"]}:#{ENV["CATALOG_PORT"]}"
-  config.logger = Catalog::Api::Minion.logger
-end
-
 args = parse_args
 
 catalog_api_minion_approval = Catalog::Api::Minion::Approval.new(args[:queue_host], args[:queue_port])

--- a/bin/catalog-api-task-minion
+++ b/bin/catalog-api-task-minion
@@ -20,13 +20,6 @@ def parse_args
   opts
 end
 
-require "catalog-api-client"
-CatalogApiClient.configure do |config|
-  config.scheme = ENV["CATALOG_SCHEME"] || "http"
-  config.host   = "#{ENV["CATALOG_HOST"]}:#{ENV["CATALOG_PORT"]}"
-  config.logger = Catalog::Api::Minion.logger
-end
-
 args = parse_args
 
 catalog_api_task_minion = Catalog::Api::Minion::Task.new(args[:queue_host], args[:queue_port])

--- a/lib/catalog/api/minion/approval.rb
+++ b/lib/catalog/api/minion/approval.rb
@@ -1,4 +1,3 @@
-require "catalog-api-client"
 require "rest-client"
 require "catalog/api/minion/base"
 

--- a/lib/catalog/api/minion/base.rb
+++ b/lib/catalog/api/minion/base.rb
@@ -1,6 +1,5 @@
 require "manageiq-messaging"
 require "catalog/api/minion/logging"
-require "catalog-api-client"
 require "uri"
 
 module Catalog
@@ -72,10 +71,9 @@ module Catalog
         end
 
         def internal_notify_url(path)
-          config = ::CatalogApiClient.configure
           URI::HTTP.build(
-            :host   => config.host.split(":").first,
-            :port   => config.host.split(":").last,
+            :host   => ENV["CATALOG_HOST"],
+            :port   => ENV["CATALOG_PORT"],
             :path   => path
           ).to_s
         end

--- a/spec/catalog/api/minion/approval_spec.rb
+++ b/spec/catalog/api/minion/approval_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe Catalog::Api::Minion::Approval do
       { :payload =>  message.payload, :message => message.message }
     end
     let(:event) { "request_started" }
-    let(:config) do
-      test_config = ::CatalogApiClient.configure
-      test_config.host = "localhost:3000"
+
+    around do |example|
+      with_modified_env(:CATALOG_HOST => 'localhost', :CATALOG_PORT => '3000') do
+        example.call
+      end
     end
 
     before do
-      dummy_client = double("CatalogApiClient")
-      allow(dummy_client).to receive(:configure).and_return(config)
       stub_request(:post, "http://localhost:3000/internal/v1.0/notify/approval_request/3")
     end
 

--- a/spec/catalog/api/minion/task_spec.rb
+++ b/spec/catalog/api/minion/task_spec.rb
@@ -13,14 +13,14 @@ describe Catalog::Api::Minion::Task do
     let(:payload_params) do
       {:payload => message.payload, :message => message.message}
     end
-    let(:config) do
-      test_config = ::CatalogApiClient.configure
-      test_config.host = "localhost:3000"
+
+    around do |example|
+      with_modified_env(:CATALOG_HOST => 'localhost', :CATALOG_PORT => '3000') do
+        example.call
+      end
     end
 
     before do
-      dummy_client = double("CatalogApiClient")
-      allow(dummy_client).to receive(:configure).and_return(config)
       stub_request(:post, "http://localhost:3000/internal/v1.0/notify/task/123")
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,13 @@ raise "Specs must be run in test environment" if ENV["RAILS_ENV"] != "test"
 
 require "webmock/rspec"
 require "catalog/api/minion/logging"
+require "climate_control"
+
 Catalog::Api::Minion.logger = Logger.new("/dev/null")
+
+def with_modified_env(options, &block)
+  ClimateControl.modify(options, &block)
+end
 
 RSpec.configure do |config|
   # config.use_transactional_fixtures = true


### PR DESCRIPTION
The minion directly talks to the Catalog API and doesn't use
the generated client.

Uses the env var CATALOG_HOST and CATALOG_PORT

![Screen Shot 2020-03-04 at 10 16 47 AM](https://user-images.githubusercontent.com/6452699/75893803-54dd7800-5e01-11ea-8b69-a76281839872.png)
