### PR TITLE
Use 'id' key to fetch the task id from within a kafka task payload

### DIFF
--- a/lib/catalog/api/minion/task.rb
+++ b/lib/catalog/api/minion/task.rb
@@ -22,7 +22,7 @@ module Catalog
         private
 
         def post_internal_notify(payload, payload_params, headers)
-          RestClient.post(internal_notify_url(payload['task_id']), payload_params, headers)
+          RestClient.post(internal_notify_url(payload['id']), payload_params, headers)
         end
 
         def internal_notify_url(task_id)

--- a/spec/catalog/api/minion/task_spec.rb
+++ b/spec/catalog/api/minion/task_spec.rb
@@ -9,7 +9,7 @@ describe Catalog::Api::Minion::Task do
 
     let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, "Task.update", payload, headers, nil, nil) }
 
-    let(:payload) { {"task_id" => "123"} }
+    let(:payload) { {"id" => "123"} }
     let(:payload_params) do
       {:payload => message.payload, :message => message.message}
     end
@@ -20,12 +20,8 @@ describe Catalog::Api::Minion::Task do
       end
     end
 
-    before do
-      stub_request(:post, "http://localhost:3000/internal/v1.0/notify/task/123")
-    end
-
     context "when there is no error" do
-      it "posts a payload to the order item endpoint" do
+      it "posts a payload to the order item endpoint with a task id" do
         task_minion.perform(message)
         expect(a_request(:post, "http://localhost:3000/internal/v1.0/notify/task/123").with(
           :body    => payload_params,


### PR DESCRIPTION
~~This is necessary because the task update kafka messages can potentially have either task_id or id as the identification key in the payload.~~

"task_id" is the incorrect key that should be coming back from the kafka events, and we should be using "id" instead.

@syncrou @gmcculloug 

Related PRs:
>Topo Persister PR that precipited this change: ?>https://github.com/RedHatInsights/topological_inventory-persister/pull/56/files
>
>Topo Operations PR that allows this change to work for either operations / persister based events:
>RedHatInsights/topological_inventory-api#301