### PR TITLE
Moved CodeClimate to before/after script sections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ rvm:
   - 2.5.7
   - 2.6.5
 before_install:
+- gem install bundler
+before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
   > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 - "./cc-test-reporter before-build"
-- gem install bundler
-before_script:
+after_script:
+- "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"


### PR DESCRIPTION
Was trying to figure out why we were not getting CodeClimate reports for these repos and realized I had it running in the wrong section in travis config file.

This PR moves CodeClimate logic into `before_script` and also adds the `after_script` section that was missing.