### PR TITLE
Update Readme to reflect deprecated status

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Usage
 
-TODO: Write usage instructions here
+This project has been deprecated and is no longer in use. It has been replaced with various listeners stemming from [KafkaListener](https://github.com/RedHatInsights/catalog-api/blob/master/lib/kafka_listener.rb) directly in the catalog project.
 
 ## Development
 


### PR DESCRIPTION
https://github.com/RedHatInsights/e2e-deploy/pull/2237 and https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/9237 have removed minion deployments, and thus we should at the very least update the readme to reflect that.